### PR TITLE
Fix thread local abuse

### DIFF
--- a/inc/signalwire-client-c/handle_state.h
+++ b/inc/signalwire-client-c/handle_state.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 SignalWire, Inc
+ * Copyright (c) 2018-2019 SignalWire, Inc
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -98,18 +98,20 @@ struct swclt_hstate_change_request {
  * is enabled, will include the file/line where the state change was initiated from. */
 static inline const char *swclt_hstate_describe_change(const swclt_hstate_change_t *pending_state_change)
 {
+	static KS_THREAD_LOCAL char buf[1024] = { 0 };
 #if defined(KS_BUILD_DEBUG)
-	return ks_thr_sprintf("[%s=>%s] Status: %d Reason: %s\nLocation: %s:%d:%s",
+	snprintf(buf, sizeof(buf), "[%s=>%s] Status: %d Reason: %s\nLocation: %s:%d:%s",
 		swclt_hstate_str(pending_state_change->old_state),
 		swclt_hstate_str(pending_state_change->new_state),
 		pending_state_change->status, pending_state_change->reason,
 		pending_state_change->file, pending_state_change->line, pending_state_change->tag);
 #else
-	return ks_thr_sprintf("[%s=>%s] Status: %d Reason: %s",
+	snprintf(buf, sizeof(buf), "[%s=>%s] Status: %d Reason: %s",
 		swclt_hstate_str(pending_state_change->old_state),
 		swclt_hstate_str(pending_state_change->new_state),
 		pending_state_change->status, pending_state_change->reason);
 #endif
+	return buf;
 }
 
 /* Private handle state apis used internally, but still exposed for unit tests */

--- a/inc/signalwire-client-c/internal/command.h
+++ b/inc/signalwire-client-c/internal/command.h
@@ -76,11 +76,6 @@ struct swclt_cmd_ctx {
 	 * with no error) and error (when remove replies with an error */
 	SWCLT_CMD_TYPE type;
 
-	/* Since we have a context for the command, we cache the rendering to an unformatted
-	 * string */
-	SWCLT_CMD_TYPE cached_type;
-	char *cached_string;
-
 	/* This is the time to live value, when non zero, the command will fail if the
 	 * response is not received within the appropriate window. */
 	uint32_t response_ttl_ms;

--- a/src/command.c
+++ b/src/command.c
@@ -281,7 +281,7 @@ static ks_status_t __print_request(swclt_cmd_ctx_t *ctx, ks_pool_t *pool, char *
 		ks_json_delete(&jsonrpc_request);
 	}
 
-	/* And give the caller a read only copy */
+	/* And give the caller a copy */
 	*string = ks_pstrdup(pool, ctx->cached_string);
 	return KS_STATUS_SUCCESS;
 }
@@ -316,8 +316,8 @@ static ks_status_t __print_result(swclt_cmd_ctx_t *ctx, ks_pool_t *pool, char **
 		ks_json_delete(&jsonrpc_result);
 	}
 
-	/* And give the caller a read only copy */
-	*string = ctx->cached_string;
+	/* And give the caller a copy */
+	*string = ks_pstrdup(pool, ctx->cached_string);
 	return KS_STATUS_SUCCESS;
 }
 

--- a/src/command.c
+++ b/src/command.c
@@ -219,7 +219,6 @@ static void __context_deinit(swclt_cmd_ctx_t *ctx)
 	ks_pool_free(&ctx->method);
 	ks_pool_free(&ctx->id_str);
 	ks_json_delete((ks_json_t **)&ctx->request);
-	ks_json_free(&ctx->cached_string);
 	ks_json_delete(&ctx->reply.error);
 	ks_pool_free(&ctx->failure_summary);
 	ks_pool_free(&ctx->failure_reason);
@@ -258,101 +257,73 @@ static ks_json_t * __wrap_jsonrpc(swclt_cmd_ctx_t *ctx, const char *version,
 
 static ks_status_t __print_request(swclt_cmd_ctx_t *ctx, ks_pool_t *pool, char ** const string)
 {
-	/* Default to own pool if not set */
+	ks_json_t *jsonrpc_request;
+
 	if (!pool)
 		pool = ctx->base.pool;
 
-	if (ctx->type != ctx->cached_type) {
-		ks_json_t *jsonrpc_request;
-
-		ks_pool_free(&ctx->cached_string);
-
-		/* Wrap the request and updated the cache */
-		jsonrpc_request = __wrap_jsonrpc(ctx, "2.0", ctx->method,
+	jsonrpc_request = __wrap_jsonrpc(ctx, "2.0", ctx->method,
 			ctx->id_str, ks_json_pduplicate(ctx->base.pool, (ks_json_t *)ctx->request, KS_TRUE), NULL, NULL);
-		if (!jsonrpc_request)
-			return KS_STATUS_NO_MEM;
-		ctx->cached_string = ks_json_pprint_unformatted(ctx->base.pool, jsonrpc_request);
-		if (!ctx->cached_string) {
-			ks_json_delete(&jsonrpc_request);
-			return KS_STATUS_NO_MEM;
-		}
-		ctx->cached_type = ctx->type;
+	if (!jsonrpc_request)
+		return KS_STATUS_NO_MEM;
+	*string = ks_json_pprint_unformatted(ctx->base.pool, jsonrpc_request);
+	if (!*string) {
 		ks_json_delete(&jsonrpc_request);
+		return KS_STATUS_NO_MEM;
 	}
+	ks_json_delete(&jsonrpc_request);
 
-	/* And give the caller a copy */
-	*string = ks_pstrdup(pool, ctx->cached_string);
 	return KS_STATUS_SUCCESS;
 }
 
 static ks_status_t __print_result(swclt_cmd_ctx_t *ctx, ks_pool_t *pool, char **string)
 {
+	ks_json_t *jsonrpc_result;
 	if (ctx->type != SWCLT_CMD_TYPE_RESULT) {
 		ks_log(KS_LOG_WARNING, "Attempt to print incorrect result type, command type is: %s", swclt_cmd_type_str(ctx->type));
 		return KS_STATUS_INVALID_ARGUMENT;
 	}
 
-	/* Default to own pool if not set */
 	if (!pool)
 		pool = ctx->base.pool;
 
-	if (ctx->type != ctx->cached_type) {
-		ks_json_t *jsonrpc_result;
-
-		ks_pool_free(&ctx->cached_string);
-
-		/* Wrap the result and updated the cache */
-		jsonrpc_result = __wrap_jsonrpc(ctx, "2.0", NULL,
-			ctx->id_str, NULL, ks_json_pduplicate(pool, ctx->reply.result, KS_TRUE), NULL);
-		if (!jsonrpc_result)
-			return KS_STATUS_NO_MEM;
-		ctx->cached_string = ks_json_pprint_unformatted(ctx->base.pool, jsonrpc_result);
-		if (!ctx->cached_string) {
-			ks_json_delete(&jsonrpc_result);
-			return KS_STATUS_NO_MEM;
-		}
-		ctx->cached_type = ctx->type;
+	jsonrpc_result = __wrap_jsonrpc(ctx, "2.0", NULL,
+		ctx->id_str, NULL, ks_json_pduplicate(pool, ctx->reply.result, KS_TRUE), NULL);
+	if (!jsonrpc_result)
+		return KS_STATUS_NO_MEM;
+	*string = ks_json_pprint_unformatted(ctx->base.pool, jsonrpc_result);
+	if (!*string) {
 		ks_json_delete(&jsonrpc_result);
+		return KS_STATUS_NO_MEM;
 	}
+	ks_json_delete(&jsonrpc_result);
 
-	/* And give the caller a copy */
-	*string = ks_pstrdup(pool, ctx->cached_string);
 	return KS_STATUS_SUCCESS;
 }
 
 static ks_status_t __print_error(swclt_cmd_ctx_t *ctx, ks_pool_t *pool, char **string)
 {
+	ks_json_t *jsonrpc_error;
+
 	if (ctx->type != SWCLT_CMD_TYPE_ERROR) {
 		ks_log(KS_LOG_WARNING, "Attempt to print incorrect error type, command type is: %s", swclt_cmd_type_str(ctx->type));
 		return KS_STATUS_INVALID_ARGUMENT;
 	}
 
-	/* Default to own pool if not set */
 	if (!pool)
 		pool = ctx->base.pool;
 
-	if (ctx->type != ctx->cached_type) {
-		ks_json_t *jsonrpc_error;
-
-		ks_pool_free(&ctx->cached_string);
-
-		/* Wrap the error and updated the cache */
-		jsonrpc_error = __wrap_jsonrpc(ctx, "2.0", NULL,
-			ctx->id_str, NULL, NULL, ks_json_pduplicate(pool, ctx->reply.error, KS_TRUE));
-		if (!jsonrpc_error)
-			return KS_STATUS_NO_MEM;
-		ctx->cached_string = ks_json_pprint_unformatted(ctx->base.pool, jsonrpc_error);
-		if (!ctx->cached_string) {
-			ks_json_delete(&jsonrpc_error);
-			return KS_STATUS_NO_MEM;
-		}
-		ctx->cached_type = ctx->type;
+	jsonrpc_error = __wrap_jsonrpc(ctx, "2.0", NULL,
+		ctx->id_str, NULL, NULL, ks_json_pduplicate(pool, ctx->reply.error, KS_TRUE));
+	if (!jsonrpc_error)
+		return KS_STATUS_NO_MEM;
+	*string = ks_json_pprint_unformatted(ctx->base.pool, jsonrpc_error);
+	if (!*string) {
 		ks_json_delete(&jsonrpc_error);
+		return KS_STATUS_NO_MEM;
 	}
+	ks_json_delete(&jsonrpc_error);
 
-	/* And give the caller a copy */
-	*string = ks_pstrdup(pool, ctx->cached_string);
 	return KS_STATUS_SUCCESS;
 }
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -370,7 +370,7 @@ static void __context_describe(swclt_conn_ctx_t *ctx, char *buffer, ks_size_t bu
 	/* We have to do all this garbage because of the poor decision to nest ks_handle_describe() calls that return a common thread local buffer */
 	const char *desc = ks_handle_describe(ctx->wss);
 	ks_size_t desc_len = strlen(desc);
-	const char preamble_buf[256] = { 0 };
+	char preamble_buf[256] = { 0 };
 	ks_size_t preamble_len = 0;
 	snprintf(preamble_buf, sizeof(preamble_buf), "SWCLT Connection to %s:%d - ", ctx->info.wss.address, ctx->info.wss.port);
 	preamble_len = strlen(preamble_buf);

--- a/src/handle_state.c
+++ b/src/handle_state.c
@@ -143,7 +143,6 @@ SWCLT_DECLARE(void) __swclt_hstate_changed(
 		/* FORCE logging on from here on out */
 		//swclt_enable_log_output(KS_LOG_LEVEL_DEBUG);
 #endif
-
 		ks_log(KS_LOG_WARNING, "Handle: %s state changed: %s for handle: %s", swclt_htype_str(KS_HANDLE_TYPE_FROM_HANDLE(ctx->handle)),
 			swclt_hstate_describe_change(ctx->pending_state_change_notification), ks_handle_describe(ctx->handle));
 	} else {

--- a/src/transport/websocket.c
+++ b/src/transport/websocket.c
@@ -461,6 +461,8 @@ SWCLT_DECLARE(ks_status_t) swclt_wss_write_cmd(swclt_wss_t wss, swclt_cmd_t cmd)
 	else
 		ks_throughput_report_ex(ctx->rate_send, len, KS_FALSE);
 
+	ks_pool_free(&data);
+
 	SWCLT_WSS_SCOPE_END(wss, ctx, status)
 }
 


### PR DESCRIPTION
Remove use of unsafe `ks_thr_sprintf()`.
Fixed case of memory pool swelling in `websocket.c`
Removed unused cache.