### PR TITLE
Remove 2 log entries that are at CRIT level that cause sentry alerts

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -615,7 +615,6 @@ SWCLT_DECLARE(ks_status_t) __swclt_cmd_error(swclt_cmd_t cmd, const ks_json_t **
 
 	if (ctx->type != SWCLT_CMD_TYPE_ERROR) {
 		status = KS_STATUS_INVALID_ARGUMENT;
-		ks_log(KS_LOG_CRIT, "Invalid type except SWCLT_CMD_TYPE_ERROR");
 		goto done;
 	}
 
@@ -635,7 +634,6 @@ SWCLT_DECLARE(ks_status_t) __swclt_cmd_result(swclt_cmd_t cmd, const ks_json_t *
 
 	if (ctx->type != SWCLT_CMD_TYPE_RESULT) {
 		status = KS_STATUS_INVALID_ARGUMENT;
-		ks_log(KS_LOG_CRIT, "Invalid type expected result");
 		goto done;
 	}
 


### PR DESCRIPTION
The functions already report back with error returns and often have additional logging on that at better locations for what is wrong.
The swclt_cmd_result function is often used to determine if an error occurred by not having a result present, and this causes chatty sentry logs.  @mjerris asked if we could do something about this, I removed the log lines as unneccessary if @crienzo agrees.