### PR TITLE
[Installation] On CentOS install to /usr/lib64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ if(KS_PLAT_LIN)
 	find_package(Git)
 	find_program(GZIP_CMD gzip)
 	find_program(DATE_CMD date)
+	include(GNUInstallDirs)
 endif()
 
 # Fixes build on older gcc, Debian Jessie
@@ -79,6 +80,9 @@ endif()
 if("${CMAKE_OS_NAME}" STREQUAL "Centos")
 
 	# Enable component install
+	# Install shared libraries to /usr/lib64
+	set(CMAKE_INSTALL_LIBDIR lib64 CACHE PATH "Library installation location" FORCE)
+	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 	set(CPACK_RPM_COMPONENT_INSTALL ON)
 
 	# Find stuff we need for packaging on Centos
@@ -306,7 +310,7 @@ include(CPack)
 # us to run the apps from the build dir without installing (come install time
 # the binary is re-linked with an rpath matching that of the install prefix)
 set(SKIP_BUILD_RPATH TRUE)
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 # Use the link path for the rpath
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
@@ -390,7 +394,7 @@ set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}")
 
 if (NOT KS_PLAT_WIN)
 	# Set install targets
-	install(TARGETS signalwire_client COMPONENT "runtime" EXPORT SignalWireClientConfig DESTINATION lib)
+	install(TARGETS signalwire_client COMPONENT "runtime" EXPORT SignalWireClientConfig DESTINATION ${CMAKE_INSTALL_LIBDIR})
 	install(DIRECTORY inc/signalwire-client-c COMPONENT "runtime" DESTINATION include PATTERN internal EXCLUDE)
 
 	# Set path for pkg-config based on ARCH and distro type

--- a/signalwire_client.pc.in
+++ b/signalwire_client.pc.in
@@ -1,6 +1,6 @@
 prefix=@PC_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/lib
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 definitions=@PC_DEFINITIONS@
 


### PR DESCRIPTION
This is the companion PR to https://github.com/signalwire/libks/pull/75.

On CentOS install  shared libraries to /usr/lib64.