### PR TITLE
Update GHA workflow trigger branch from v2.0 to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ on:
   pull_request:
     types: [synchronize, opened]
     branches:
-      - "v2.0"
+      - "master"
   push:
     branches:
-      - "v2.0"
+      - "master"
 
 jobs:
   scan_build:


### PR DESCRIPTION
I spoke with Andrey today and it was determined that this repo needs workflows to run on updates to the master branch. This PR should address that.